### PR TITLE
allow not to use the config file, inject the config before loading xhprofio

### DIFF
--- a/xhprof/includes/bootstrap.inc.php
+++ b/xhprof/includes/bootstrap.inc.php
@@ -36,7 +36,10 @@ require BASE_PATH . '/includes/helpers.xhprof.inc.php';
 set_exception_handler('ay\error_exception_handler');
 set_error_handler('ay\error_exception_handler');
 
-$config	= require BASE_PATH . '/includes/config.inc.php';
+if(!isset($config) || !is_array($config))
+{
+    $config	= require BASE_PATH . '/includes/config.inc.php';
+}
 
 if(!isset($config['base_url'], $config['pdo']))
 {


### PR DESCRIPTION
this allows users to inject the config without the config file in the xhprof.io directory.
for example ...

``` php
 $config = array (
            'base_url'      => '....',
            'pdo'           => ....,
 );

 require_once __DIR__.'/../vendors/xhprofio/index.php';
```

why this is important?

if you would like to add xhprof.io to an existing project as submodule, you dont want to change files in xhprof.io. So the configuration must be injectable
